### PR TITLE
Async CLI Refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,7 +337,7 @@ dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot",
  "signal-hook",
  "signal-hook-mio",
@@ -404,6 +410,95 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -493,6 +588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +681,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +705,17 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -690,6 +808,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,13 +829,17 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 name = "portscanner"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "colored",
  "crossterm",
+ "futures",
+ "ipnet",
  "num_cpus",
  "ratatui",
  "rayon",
+ "tokio",
  "zip",
 ]
 
@@ -877,7 +1011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
  "signal-hook",
 ]
 
@@ -891,10 +1025,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "stability"
@@ -975,6 +1125,31 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+dependencies = [
+ "libc",
+ "mio 1.1.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "typenum"
@@ -1197,6 +1372,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,11 +1413,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1240,6 +1450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1466,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1264,10 +1486,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1282,6 +1516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1532,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1306,6 +1552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1568,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ crossterm = "0.27"
 zip = "0.6"
 num_cpus = "1.16"
 chrono = "0.4.42"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "fs", "net"] }
+ipnet = "2"
+futures = "0.3"
+anyhow = "1.0"
 
 [package.metadata.deb]
 name = "rust-portscanner"

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # portscanner
 
-**Ein schneller Portscanner mit TUI, parallelem Scan, Export (ZIP) und farbiger Ausgabe.**  
-Rust · rayon für Parallelität · ratatui + crossterm für TUI · clap für CLI · colored für Terminalfarben · zip für Export.
+**A fast port scanner with TUI, parallel scanning, ZIP export, and colored output.**  
+Rust · tokio (async) · clap for CLI · ratatui + crossterm for TUI · colored for terminal colors · zip for export.
 
 ---
 
 ## Features
 
-- Paralleler TCP-Connect-Scan  
-- Portlisten und Bereiche (z. B. `22,80,8000-8100`)  
-- IPv4 / IPv6 Unterstützung  
-- Konfigurierbares Timeout und Threadanzahl  
-- Interaktive TUI-Ansicht  
-- Export (CSV/JSON) in ZIP-Archiv  
-- Farbige Terminalausgabe  
+- Parallel TCP connect scan
+- Port lists and ranges (e.g. `22,80,8000-8100`)
+- IPv4 / IPv6 Ready  
+- Configurable Timeout and Threadcount
+- Interactive TUI-View  
+- Export in ZIP-Archive  
+- Colored Terminaloutput  
 
 ---
 
 ## Installation
 
-### Voraussetzungen
-- Rust (aktuelle stable Toolchain)  
-- cargo verfügbar  
+### Requirements
+- Rust (actual stable version)  
+- cargo ready  
 
-### Repository klonen
-    git clone <repo-url>
+### Clone Repository
+    git clone https://github.com/Addereum/rust-portscanner
     cd portscanner
 
 ### Build (Debug)
@@ -32,88 +32,101 @@ Rust · rayon für Parallelität · ratatui + crossterm für TUI · clap für CL
 
 ### Build (Release)
     cargo build --release
-    # Binär liegt in target/release/portscanner
 
-### Installieren (global)
+### binary in target/release/portscanner
+
+### Install (global)
     cargo install --path .
 
 ---
 
-## Nutzung / Beispiele
+## Examples
 
-### Hilfe anzeigen
+### Show Help
     cargo run -- --help
-    # oder nach Installation
+    
+### or after installation
     portscanner --help
 
-### Einfacher Scan
+### Simple Scan
     portscanner -t 192.0.2.1 -p 1-1024
 
-### Mehrere Ziele und Ports
-    portscanner -t 192.0.2.1,example.com -p 22,80,443,8000-8100
+### Multiple targets and ports
+    portscanner --targets 192.0.2.1,example.com --ports 22,80,443,8000-8100
 
-### Paralleler Scan mit Timeout und Threads
+### Parallel Scan with Timeout and Threads
     portscanner -t example.com -p 1-65535 --timeout 200 --threads 200
 
-### TUI starten
-    portscanner --tui -t 192.0.2.1 -p 1-1024
+### TUI mode (start)
+    portscanner --tui --targets 192.0.2.1 --ports 1-1024
 
-### Ergebnis exportieren
-    portscanner -t example.com -p 1-1024 --export results.zip
+### Export results
+
+    portscanner --targets example.com --ports 1-1024 --format zip
 
 ---
 
-## Entwickeln & Debugging
+## Development & Debugging
 
-Tests:
-    cargo test
+### Tests
+```bash
+cargo test
+```
 
-Formatierung:
-    cargo fmt
+Formatting:
+```bash
+cargo fmt
+```
 
 Lint / Clippy:
-    cargo clippy --all-targets --all-features -- -D warnings
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
 
-Debug-Beispiel:
-    cargo run -- -t 127.0.0.1 -p 22,80
+Debug example:
+```bash
+ cargo run -- -t 127.0.0.1 -p 22,80
+ ```
 
 ---
 
 ## Packaging / Debian
 
-Mit cargo-deb:
-    cargo install cargo-deb
-    cargo build --release
-    cargo deb --target x86_64-unknown-linux-gnu
+With `cargo-deb`:
+```bash
+cargo install cargo-deb
+cargo build --release
+cargo deb --target x86_64-unknown-linux-gnu
+```
 
 ---
 
-## Sicherheit & Haftung
+## Security & Liability
 
-Scanne nur Netzwerke, für die du eine ausdrückliche Erlaubnis hast.  
-Unautorisierte Scans sind in vielen Jurisdiktionen rechtswidrig.  
-Keine Haftung durch den Autor.
+Only scan networks for which you have explicit permission.  
+Unauthorized scanning may be illegal in many jurisdictions.  
+The author accepts no liability or warranty.
 
 ---
 
 ## License
 
-GPL-3.0 (Datei LICENSE).
-- GPL-3.0: Copyleft, zwingt abgeleitete Werke bei Verteilung offen zu bleiben  
+GPL-3.0 (see `LICENSE` file).
+- GPL-3.0: Copyleft — requires derivative works to remain open source when distributed.
 
 ---
 
 ## Contribution
 
-1. Fork  
-2. Branch `feature/...` oder `fix/...`  
-3. Commit mit klarer Nachricht  
-4. Pull Request öffnen  
+1. Fork the repository
+2. Create a branch named `feature/...` or `fix/...`
+3. Commit with a clear message
+4. Open a Pull Request
 
-Bitte cargo fmt und Tests ausführen.
+Please run `cargo fmt` and all tests before submitting.
 
 ---
 
-## Kontakt
+## Contact
 
 Lukas Roß <contact@lukas-ross.de>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,79 @@
+// src/cli.rs
+use anyhow::{Result, bail};
+use clap::Parser;
+use ipnet::IpNet;
+use std::str::FromStr;
+
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "Portscanner CLI - supports CIDR, ports, async scanning"
+)]
+pub struct Opts {
+    /// comma separated targets, hostnames, IPs or CIDR (e.g. 192.0.2.0/28 or example.com)
+    #[arg(short, long, default_value = "127.0.0.1")]
+    pub targets: String,
+
+    /// ports (e.g. "22,80,8000-8100")
+    #[arg(short, long, default_value = "80,443")]
+    pub ports: String,
+
+    /// timeout per connect in milliseconds
+    #[arg(long, default_value_t = 300)]
+    pub timeout: u64,
+
+    /// concurrency (parallel connections)
+    #[arg(long, default_value_t = 200)]
+    pub concurrency: usize,
+
+    /// export format: txt|html|zip
+    #[arg(long, default_value = "txt")]
+    pub format: Format,
+
+    /// start old TUI (interactive)
+    #[arg(long)]
+    pub tui: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Format {
+    Txt,
+    Html,
+    Zip,
+}
+
+impl FromStr for Format {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "txt" => Ok(Format::Txt),
+            "html" => Ok(Format::Html),
+            "zip" => Ok(Format::Zip),
+            _ => Err(format!("unknown format: {}", s)),
+        }
+    }
+}
+
+/// Expand targets string into Vec<String>.
+/// Supports hostnames and CIDR ranges. Limits to `max_hosts` entries.
+pub fn expand_targets(input: &str, max_hosts: usize) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    for part in input.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        if let Ok(net) = part.parse::<IpNet>() {
+            // ipnet::IpNet::hosts() yields IpAddr iterator
+            for ip in net.hosts() {
+                out.push(ip.to_string());
+                if out.len() > max_hosts {
+                    bail!("CIDR expansion too large (> {})", max_hosts);
+                }
+            }
+        } else {
+            out.push(part.to_string());
+        }
+    }
+    if out.is_empty() {
+        bail!("no targets provided");
+    }
+    Ok(out)
+}

--- a/src/io_utils.rs
+++ b/src/io_utils.rs
@@ -1,0 +1,86 @@
+// src/io_utils.rs
+use anyhow::Result;
+use std::collections::HashMap;
+use std::io::Write;
+use tokio::fs;
+
+/// Formats scan results into plain text.
+pub fn make_txt(results: &HashMap<String, Vec<(u16, bool)>>) -> String {
+    let mut out = String::new();
+    for (target, vec) in results {
+        out.push_str(&format!("Scan for: {}\n\n", target));
+        for (port, open) in vec {
+            out.push_str(&format!(
+                "Port {}: {}\n",
+                port,
+                if *open { "open" } else { "closed" }
+            ));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Formats scan results into HTML.
+pub fn make_html(results: &HashMap<String, Vec<(u16, bool)>>) -> String {
+    use chrono::Local;
+    let mut html = String::new();
+    html.push_str(r#"<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Portscan</title><style>body{font-family:Segoe UI,Arial,sans-serif;margin:20px}table{border-collapse:collapse;width:100%}th,td{padding:8px;border-bottom:1px solid #ddd}th{background:#0078d4;color:#fff}</style></head><body>"#);
+    for (target, vec) in results {
+        html.push_str(&format!("<h2>Scan results for {}</h2>", target));
+        html.push_str("<table><thead><tr><th>Port</th><th>Status</th></tr></thead><tbody>");
+        for (port, open) in vec {
+            let status = if *open {
+                "<span style=\"color:#008000;font-weight:bold\">Open</span>"
+            } else {
+                "<span style=\"color:#c00;font-weight:bold\">Closed</span>"
+            };
+            html.push_str(&format!("<tr><td>{}</td><td>{}</td></tr>", port, status));
+        }
+        html.push_str("</tbody></table>");
+    }
+    html.push_str(&format!(
+        "<footer>Generated at {}</footer></body></html>",
+        Local::now().format("%Y-%m-%d %H:%M:%S")
+    ));
+    html
+}
+
+/// Export results according to chosen format.
+/// Uses async fs for txt/html and spawn_blocking for zip creation.
+pub async fn export_results(
+    results: &HashMap<String, Vec<(u16, bool)>>,
+    format: super::cli::Format,
+) -> Result<()> {
+    match format {
+        super::cli::Format::Txt => {
+            let txt = make_txt(results);
+            fs::write("scan.txt", txt).await?;
+        }
+        super::cli::Format::Html => {
+            let html = make_html(results);
+            fs::write("scan.html", html).await?;
+        }
+        super::cli::Format::Zip => {
+            let txt = make_txt(results);
+            let html = make_html(results);
+            // blocking zip creation
+            let txt_owned = txt.clone();
+            let html_owned = html.clone();
+            tokio::task::spawn_blocking(move || -> Result<(), anyhow::Error> {
+                let file = std::fs::File::create("scan_export.zip")?;
+                let mut zip = zip::ZipWriter::new(file);
+                let options = zip::write::FileOptions::default()
+                    .compression_method(zip::CompressionMethod::Deflated);
+                zip.start_file("scan.txt", options)?;
+                zip.write_all(txt_owned.as_bytes())?;
+                zip.start_file("scan.html", options)?;
+                zip.write_all(html_owned.as_bytes())?;
+                zip.finish()?;
+                Ok(())
+            })
+            .await??;
+        }
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,79 @@
 // src/main.rs
-// main.rs — thin like cheap toilet paper.
-// Launches a wobbly TUI, punts to a blocking scanner, and prints errors like haikus.
-// TODO: return proper exit codes, add a panic hook to unbrick the terminal, and stop pretending println! is observability.
-
+mod cli;
+mod io_utils;
 mod scan;
 mod tui;
 mod utils;
 
-use scan::run_scan;
-use tui::start_tui;
+use anyhow::Result;
+use clap::Parser;
+use std::sync::mpsc;
 
-// If this "app" had any less structure, it would be a gas.
-fn main() {
-    //Err::<(), std::io::Error>(std::io::Error::new(ErrorKind::NetworkDown, "")).expect("TUI-Fehler");
-    let result = start_tui();
+#[tokio::main]
+async fn main() -> Result<()> {
+    let opts = cli::Opts::parse();
 
-    match result {
-        Ok((target, ports, format, tx)) => {
-            if let Err(e) = run_scan(&target, &ports, format, tx) {
-                eprintln!("Scan-Fehler: {}", e);
+    // If user requested TUI, run TUI and collect options from it
+    if opts.tui {
+        match tui::start_tui() {
+            Ok((target, ports, format_str, tx)) => {
+                // convert format_str to enum
+                let format = match format_str {
+                    "html" => cli::Format::Html,
+                    "zip" => cli::Format::Zip,
+                    _ => cli::Format::Txt,
+                };
+
+                // parse ports
+                let ports_vec = match utils::parse_ports(&ports) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("Port parse error: {}", e);
+                        return Ok(());
+                    }
+                };
+
+                // expand single target (no CIDR in TUI)
+                let targets = vec![target];
+
+                let sender = Some(tx);
+                let results = scan::run_scan_async(&targets, &ports_vec, 300, 200, sender).await?;
+                io_utils::export_results(&results, format).await?;
+                return Ok(());
+            }
+            Err(e) => {
+                eprintln!("TUI error: {}", e);
+                return Ok(());
             }
         }
-        Err(e) => {
-            eprintln!("TUI-Fehler: {}", e);
-        }
     }
+
+    // Non-TUI CLI path
+    // Expand targets (max 1024 host entries by default)
+    let targets = cli::expand_targets(&opts.targets, 1024)?;
+    let ports = utils::parse_ports(&opts.ports)?;
+
+    // Create a simple logging channel for progress (prints to stdout)
+    let (tx_log, rx_log) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        while let Ok(line) = rx_log.recv() {
+            println!("{}", line);
+        }
+    });
+
+    // run async scan
+    let results = scan::run_scan_async(
+        &targets,
+        &ports,
+        opts.timeout,
+        opts.concurrency,
+        Some(tx_log),
+    )
+    .await?;
+
+    // export results
+    io_utils::export_results(&results, opts.format).await?;
+
+    println!("Done.");
+    Ok(())
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,235 +1,70 @@
 // src/scan.rs
-use std::fs::File;
-use std::io::Write;
-use std::net::{TcpStream, ToSocketAddrs};
+use anyhow::Result;
+use futures::stream::{self, StreamExt};
+use std::collections::HashMap;
 use std::sync::mpsc::Sender;
-use std::time::{Duration, Instant};
-use zip::ZipWriter;
-use zip::write::FileOptions;
+use std::time::Instant;
+use tokio::time::{Duration, timeout};
 
-use rayon::ThreadPoolBuilder;
-use rayon::prelude::*;
-
-/// Max parallel worker threads. Tune this for your machine/network.
-/// Consider making this configurable (CLI or config file).
-const CONCURRENCY: usize = 64;
-
-pub fn run_scan(
-    target: &str,
-    ports_str: &str,
-    format: &str,
-    tx: Sender<String>,
-) -> std::io::Result<()> {
-    let ports = match crate::utils::parse_ports(ports_str) {
-        Ok(p) => p,
-        Err(e) => {
-            tx.send(format!("❌ Port-Eingabe ungültig: {e}")).ok();
-            return Ok(());
-        }
-    };
-
-    run_scan_from_vec(target, &ports, format, tx)
-}
-
-fn run_scan_from_vec(
-    target: &str,
+/// Async scanner: iterate targets, scan ports concurrently.
+/// Sends textual progress messages via `tx`.
+pub async fn run_scan_async(
+    targets: &[String],
     ports: &[u16],
-    format: &str,
-    tx: Sender<String>,
-) -> std::io::Result<()> {
-    let start = Instant::now();
-    let total = ports.len();
+    timeout_ms: u64,
+    concurrency: usize,
+    tx: Option<Sender<String>>,
+) -> Result<HashMap<String, Vec<(u16, bool)>>> {
+    let start_all = Instant::now();
+    let mut map = HashMap::new();
+    let concurrency = concurrency.max(1);
 
-    tx.send(format!("🔍 Scanne {} Ports auf {}", total, target))
-        .ok();
+    for target in targets {
+        if let Some(tx) = &tx {
+            let _ = tx.send(format!("🔍 Scanning {} ports on {}", ports.len(), target));
+        }
 
-    // Build a local Rayon pool with a concurrency cap so we don't saturate the system.
-    let pool = ThreadPoolBuilder::new()
-        .num_threads(CONCURRENCY.min(num_cpus::get().max(1)))
-        .build()
-        .expect("failed to build rayon thread pool");
-
-    // Run the parallel scan inside the pool.
-    let results: Vec<(u16, bool)> = pool.install(|| {
-        ports
-            .par_iter()
+        // Stream each port and run concurrently
+        let stream = stream::iter(ports.to_owned())
             .map(|port| {
-                let addr = format!("{}:{}", target, port);
-                let mut open = false;
-
-                if let Ok(mut addrs) = addr.to_socket_addrs()
-                    && let Some(sock) = addrs.next()
-                    && TcpStream::connect_timeout(&sock, Duration::from_millis(300)).is_ok()
-                {
-                    open = true;
+                let target = target.clone();
+                async move {
+                    let addr = (target.as_str(), port);
+                    let result = timeout(
+                        Duration::from_millis(timeout_ms),
+                        tokio::net::TcpStream::connect(addr),
+                    )
+                    .await;
+                    let open = matches!(result, Ok(Ok(_)));
+                    (port, open)
                 }
+            })
+            .buffer_unordered(concurrency);
 
-                // Best-effort send progress message as soon as this port is done.
-                tx.send(format!(
-                    "Port {} {}",
-                    port,
-                    if open { "offen" } else { "geschlossen" }
-                ))
-                .ok();
-
-                (*port, open)
+        // Collect all scan results for this target
+        let mut results: Vec<(u16, bool)> = stream
+            .inspect(|res| {
+                if let Some(tx) = &tx {
+                    let _ = tx.send(format!(
+                        "Port {} {}",
+                        res.0,
+                        if res.1 { "open" } else { "closed" }
+                    ));
+                }
             })
             .collect()
-    });
+            .await;
 
-    tx.send(format!("⏱️  Scan abgeschlossen in {:.2?}", start.elapsed()))
-        .ok();
-
-    // Generate common contents once and dispatch to writers
-    let txt = generate_txt(target, &results);
-    let html = generate_html(target, &results);
-
-    match format {
-        "txt" => export_txt_content(&txt)?,
-        "html" => export_html_content(&html)?,
-        "zip" => export_zip_contents(&txt, &html)?,
-        _ => {
-            let _ = tx.send(format!("Unbekanntes Format: {}", format));
-        }
+        results.sort_by_key(|(p, _)| *p);
+        map.insert(target.clone(), results);
     }
 
-    tx.send(format!("✅ Ergebnisse exportiert als {}", format))
-        .ok();
-    Ok(())
-}
-
-/// Create plain-text content
-fn generate_txt(target: &str, results: &[(u16, bool)]) -> String {
-    let mut out = String::new();
-    out.push_str(&format!("Scan für: {}\n\n", target));
-    for (port, open) in results {
-        out.push_str(&format!(
-            "Port {}: {}\n",
-            port,
-            if *open { "offen" } else { "geschlossen" }
+    if let Some(tx) = &tx {
+        let _ = tx.send(format!(
+            "⏱️  All scans finished in {:.2?}",
+            start_all.elapsed()
         ));
     }
-    out
-}
 
-/// Create HTML content (the "pretty" corporate style)
-fn generate_html(target: &str, results: &[(u16, bool)]) -> String {
-    let mut html = String::new();
-
-    html.push_str(&format!(
-        r#"<!DOCTYPE html>
-<html lang="de">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Portscan – {target}</title>
-<style>
-    body {{
-        font-family: "Segoe UI", Arial, sans-serif;
-        background-color: #f7f9fb;
-        color: #333;
-        margin: 40px;
-        line-height: 1.5;
-    }}
-    h1 {{
-        font-size: 1.8rem;
-        border-bottom: 2px solid #0078d4;
-        padding-bottom: 6px;
-        margin-bottom: 20px;
-    }}
-    table {{
-        width: 100%;
-        border-collapse: collapse;
-        margin-top: 10px;
-        box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-    }}
-    th, td {{
-        padding: 10px 14px;
-        border-bottom: 1px solid #ddd;
-        text-align: left;
-    }}
-    th {{
-        background-color: #0078d4;
-        color: #fff;
-        font-weight: 500;
-    }}
-    tr:hover {{
-        background-color: #f1f1f1;
-    }}
-    .open {{
-        color: #008000;
-        font-weight: bold;
-    }}
-    .closed {{
-        color: #c00;
-        font-weight: bold;
-    }}
-    footer {{
-        font-size: 0.85rem;
-        color: #666;
-        text-align: right;
-        margin-top: 40px;
-    }}
-</style>
-</head>
-<body>
-<h1>Portscan-Ergebnis für {target}</h1>
-<table>
-<thead>
-<tr><th>Port</th><th>Status</th></tr>
-</thead>
-<tbody>"#
-    ));
-
-    for (port, open) in results {
-        let status = if *open {
-            r#"<span class="open">Offen</span>"#
-        } else {
-            r#"<span class="closed">Geschlossen</span>"#
-        };
-        html.push_str(&format!("<tr><td>{}</td><td>{}</td></tr>", port, status));
-    }
-
-    html.push_str(&format!(
-        r#"</tbody>
-</table>
-<footer>
-Erstellt am {} &nbsp;–&nbsp; Portscanner Export
-</footer>
-</body>
-</html>"#,
-        chrono::Local::now().format("%d.%m.%Y %H:%M:%S")
-    ));
-
-    html
-}
-
-/// write TXT file from generated content
-fn export_txt_content(txt: &str) -> std::io::Result<()> {
-    let mut file = File::create("scan.txt")?;
-    file.write_all(txt.as_bytes())?;
-    Ok(())
-}
-
-/// write HTML file from generated content
-fn export_html_content(html: &str) -> std::io::Result<()> {
-    let mut file = File::create("scan.html")?;
-    file.write_all(html.as_bytes())?;
-    Ok(())
-}
-
-/// write ZIP containing both the text and the pretty HTML
-fn export_zip_contents(txt: &str, html: &str) -> std::io::Result<()> {
-    let file = File::create("scan_export.zip")?;
-    let mut zip = ZipWriter::new(file);
-    let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
-
-    zip.start_file("scan.txt", options)?;
-    zip.write_all(txt.as_bytes())?;
-
-    zip.start_file("scan.html", options)?;
-    zip.write_all(html.as_bytes())?;
-
-    zip.finish()?;
-    Ok(())
+    Ok(map)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,52 +1,42 @@
 // src/utils.rs
-
-use clap::{Error, error::ErrorKind};
+use anyhow::{Result, bail};
 
 /// Parses a comma-separated list of ports or ranges, e.g. "22,80-85,443".
-/// Returns an error for invalid input (non-numeric, negative, >65535).
-pub fn parse_ports(input: &str) -> Result<Vec<u16>, Error> {
+/// Returns sorted unique Vec<u16> or an error.
+pub fn parse_ports(input: &str) -> Result<Vec<u16>> {
     let mut ports = Vec::new();
 
     for part in input.split(',').map(str::trim).filter(|s| !s.is_empty()) {
-        if let Some((start, end)) = part.split_once('-') {
-            let start = parse_port(start)?;
-            let end = parse_port(end)?;
+        if let Some((start_s, end_s)) = part.split_once('-') {
+            let start = parse_port(start_s)?;
+            let end = parse_port(end_s)?;
             if start > end {
-                return Err(Error::raw(
-                    ErrorKind::ValueValidation,
-                    format!("invalid range: {part}"),
-                ));
+                bail!("invalid range: {}", part);
             }
-            ports.extend(start..=end);
+            for p in start..=end {
+                ports.push(p);
+            }
         } else {
-            ports.push(parse_port(part)?);
+            let p = parse_port(part)?;
+            ports.push(p);
         }
     }
 
     if ports.is_empty() {
-        return Err(Error::raw(
-            ErrorKind::ValueValidation,
-            "no valid ports found",
-        ));
+        bail!("no valid ports found");
     }
 
+    ports.sort_unstable();
+    ports.dedup();
     Ok(ports)
 }
 
-fn parse_port(s: &str) -> Result<u16, Error> {
-    let p: i64 = s.parse().map_err(|_| {
-        Error::raw(
-            ErrorKind::ValueValidation,
-            format!("invalid port value: {s}"),
-        )
-    })?;
-
+fn parse_port(s: &str) -> Result<u16> {
+    let p: i64 = s
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid port value: {}", s))?;
     if !(0..=65535).contains(&p) {
-        return Err(Error::raw(
-            ErrorKind::ValueValidation,
-            format!("port out of range (0–65535): {s}"),
-        ));
+        bail!("port out of range (0-65535): {}", s);
     }
-
     Ok(p as u16)
 }


### PR DESCRIPTION
## Summary
This PR rewrites the `portscanner` application to use an async architecture with full CLI support, CIDR parsing, and modularized structure.

## Motivation
The previous implementation used blocking I/O, hardcoded filenames, and limited TUI-only input.  
This refactor introduces `clap`-based CLI handling, async scanning via `tokio`, and safer export logic.

## Changes
- Added new async runtime (`tokio`)
- Replaced blocking `TcpStream` with `tokio::net::TcpStream`
- Added CIDR expansion using `ipnet`
- Modularized code: `cli.rs`, `scan.rs`, `io_utils.rs`, `utils.rs`, `tui.rs`
- Implemented format selection (`txt`, `html`, `zip`) via enum
- Introduced non-blocking export with `tokio::fs` and `spawn_blocking`
- Updated README with new usage examples and English translation
- Fixed Clippy warnings and improved code style consistency

## Testing
- Ran local scans using `cargo run` with various flags:
  - `--targets 127.0.0.1 --ports 22,80`
  - `--targets 192.168.0.0/30 --ports 80,443`
  - `--format zip` and `--format html`
- Verified TUI still works interactively
- Confirmed exported files (`scan.txt`, `scan.html`, `scan_export.zip`)
- `cargo clippy --all-targets --all-features -- -D warnings` passes

## Notes
- CIDR expansion is limited to 1024 hosts for safety
- Future improvement: add async TUI and JSON export

---

**Type:** Feature / Refactor  
**Branch:** `refactor/cli-and-async-scan`  
**Author:** Lukas Roß `<contact@lukas-ross.de>`